### PR TITLE
feat: 공동구매 기능 구현

### DIFF
--- a/src/main/java/com/gophagi/nanugi/common/util/file/dto/PhotoDTO.java
+++ b/src/main/java/com/gophagi/nanugi/common/util/file/dto/PhotoDTO.java
@@ -1,14 +1,16 @@
 package com.gophagi.nanugi.common.util.file.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.gophagi.nanugi.common.util.file.domain.Photo;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
-import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
-import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
@@ -16,34 +18,41 @@ import javax.persistence.Id;
 @ToString
 public class PhotoDTO {
 
-    private Long fileId;
-    private Long uploaderId;
-    private String uploadFileName;
-    private String storeFileName;
-    private String filetype;
-    private String fileUrl;
-    private GroupbuyingBoard groupbuyingBoard;
+	private Long fileId;
+	private Long uploaderId;
+	private String uploadFileName;
+	private String storeFileName;
+	private String filetype;
+	private String fileUrl;
+	private GroupbuyingBoard groupbuyingBoard;
 
-    @Builder
-    public PhotoDTO(Long fileId, Long uploaderId, String uploadFileName, String storeFileName, String filetype, String fileUrl, GroupbuyingBoard groupbuyingBoard) {
-        this.fileId = fileId;
-        this.uploaderId = uploaderId;
-        this.uploadFileName = uploadFileName;
-        this.storeFileName = storeFileName;
-        this.filetype = filetype;
-        this.fileUrl = fileUrl;
-        this.groupbuyingBoard = groupbuyingBoard;
-    }
+	@Builder
+	public PhotoDTO(Long fileId, Long uploaderId, String uploadFileName, String storeFileName, String filetype,
+		String fileUrl, GroupbuyingBoard groupbuyingBoard) {
+		this.fileId = fileId;
+		this.uploaderId = uploaderId;
+		this.uploadFileName = uploadFileName;
+		this.storeFileName = storeFileName;
+		this.filetype = filetype;
+		this.fileUrl = fileUrl;
+		this.groupbuyingBoard = groupbuyingBoard;
+	}
 
-    public static PhotoDTO toPhotoDTO(Photo photo){
-        return PhotoDTO.builder()
-                .fileId(photo.getFileId())
-                .filetype(photo.getFiletype())
-                .storeFileName(photo.getStoreFileName())
-                .uploadFileName(photo.getUploadFileName())
-                .uploaderId(photo.getUploaderId())
-                .fileUrl(photo.getFileUrl())
-                .build();
-    }
+	public static PhotoDTO toPhotoDTO(Photo photo) {
+		return PhotoDTO.builder()
+			.fileId(photo.getFileId())
+			.filetype(photo.getFiletype())
+			.storeFileName(photo.getStoreFileName())
+			.uploadFileName(photo.getUploadFileName())
+			.uploaderId(photo.getUploaderId())
+			.fileUrl(photo.getFileUrl())
+			.build();
+	}
+
+	public static List<PhotoDTO> toPhotoDTOs(List<Photo> photos) {
+		return photos.stream()
+			.map(PhotoDTO::toPhotoDTO)
+			.collect(Collectors.toList());
+	}
 
 }

--- a/src/main/java/com/gophagi/nanugi/common/util/file/service/FileService.java
+++ b/src/main/java/com/gophagi/nanugi/common/util/file/service/FileService.java
@@ -1,88 +1,76 @@
 package com.gophagi.nanugi.common.util.file.service;
 
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import com.gophagi.nanugi.common.util.file.FileUtil;
 import com.gophagi.nanugi.common.util.file.domain.Photo;
 import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
 import com.gophagi.nanugi.common.util.file.repository.FileRepository;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
-import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FileService {
 
-    @Autowired
-    private final FileUtil fileUtil;
-    @Autowired
-    private final FileRepository fileRepository;
+	@Autowired
+	private final FileUtil fileUtil;
+	@Autowired
+	private final FileRepository fileRepository;
 
-    public List<PhotoDTO> saveFiles(Long userId, GroupbuyingBoardDTO groupbuyingBoardDTO, List<MultipartFile> files)  {
-        List<PhotoDTO> uploadItemsList = new ArrayList<>();
+	public void saveFiles(Long userId, GroupbuyingBoard groupbuyingBoard, List<MultipartFile> files) {
+		//List<MultipartFile>을 List<PhotoDTO>으로 변경하고 S3에 업로드
+		List<PhotoDTO> uploadItems = fileUtil.storeFiles(userId, files);
 
-        //List<MultipartFile>을 List<PhotoDTO>으로 변경하고 S3에 업로드
-        List<PhotoDTO> uploadItems = fileUtil.storeFiles(userId,files);
+		//DB에 파일 정보 저장
+		for (PhotoDTO uploadItem : uploadItems) {
+			saveFile(uploadItem, groupbuyingBoard);
+		}
+	}
 
-        //DB에 파일 정보 저장
-        for (PhotoDTO uploadItem : uploadItems) {
-            uploadItemsList.add(saveFile(uploadItem,groupbuyingBoardDTO));
-        }
+	public void deleteFiles(List<PhotoDTO> deleteFiles) {
 
-        return uploadItemsList;
-    }
+		//s3에서 파일삭제
+		//fileUtil.deleteFiles(deleteFiles);
 
-    public void deleteFiles(List<PhotoDTO> deleteFiles) {
+		//DB에서 파일삭제
+		for (PhotoDTO deleteFile : deleteFiles) {
+			deleteFile(deleteFile);
+		}
+	}
 
-        //s3에서 파일삭제
-        fileUtil.deleteFiles(deleteFiles);
+	/**
+	 * DB에 파일 정보 저장
+	 *
+	 * @param uploadItem
+	 * @return PhotoDTO
+	 */
+	private void saveFile(PhotoDTO uploadItem, GroupbuyingBoard groupbuyingBoard) {
+		uploadItem.setGroupbuyingBoard(groupbuyingBoard);
+		PhotoDTO saveFileDTO = PhotoDTO.toPhotoDTO(fileRepository.save(Photo.toPhoto(uploadItem)));
+		log.info("FileService saveFile : {}", saveFileDTO);
+	}
 
-        //DB에서 파일삭제
-        for (PhotoDTO deleteFile : deleteFiles) {
-            deleteFile(deleteFile);
-        }
-    }
+	/**
+	 * DB에서 사진 삭제
+	 * @param photoDTO
+	 */
+	public void deleteFile(PhotoDTO photoDTO) {
+		log.info("FileService deleteFile : {}", photoDTO);
+		fileRepository.delete(Photo.toPhoto(photoDTO));
+	}
 
+	public List<PhotoDTO> updateFiles(GroupbuyingBoard retiveBoard, List<MultipartFile> files,
+		List<PhotoDTO> deletefiles, Long userId) {
 
+		////새로 업로드한 이미지가 있으면 저장하고 삭제한 이미지는 db랑 s3에서 지우기
+		deleteFiles(deletefiles);
+		saveFiles(userId, retiveBoard, files);
 
-    /**
-     * DB에 파일 정보 저장
-     *
-     * @param uploadItem
-     * @return PhotoDTO
-     */
-    private PhotoDTO saveFile(PhotoDTO uploadItem, GroupbuyingBoardDTO groupbuyingBoardDTO) {
-
-        GroupbuyingBoard groupbuyingBoard = GroupbuyingBoard.toGroupbuyingBoard(groupbuyingBoardDTO);
-        uploadItem.setGroupbuyingBoard(groupbuyingBoard);
-        PhotoDTO saveFileDTO = PhotoDTO.toPhotoDTO(fileRepository.save(Photo.toPhoto(uploadItem)));
-        log.info("FileService saveFile : {}", saveFileDTO);
-        return saveFileDTO;
-
-    }
-
-    /**
-     * DB에서 사진 삭제
-     * @param photoDTO
-     */
-    public void deleteFile(PhotoDTO photoDTO) {
-        log.info("FileService deleteFile : {}", photoDTO);
-        fileRepository.delete(Photo.toPhoto(photoDTO));
-    }
-
-    public List<PhotoDTO> updateFiles(GroupbuyingBoardDTO retiveBoard, List<MultipartFile> files, List<PhotoDTO> deletefiles , Long userId) {
-
-        ////새로 업로드한 이미지가 있으면 저장하고 삭제한 이미지는 db랑 s3에서 지우기
-        deleteFiles(deletefiles);
-        saveFiles(userId ,retiveBoard,files);
-
-        return  null;
-    }
+		return null;
+	}
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
@@ -5,10 +5,14 @@ import javax.servlet.http.HttpSession;
 import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
 import com.gophagi.nanugi.common.util.file.service.FileService;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
+import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
+import com.gophagi.nanugi.groupbuying.dto.GroupbuyingThumbnailDTO;
 import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardCommandService;
 import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardQueryService;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,29 +33,20 @@ public class GroupbuyingController {
 		this.fileService = fileService;
 	}
 
-	//@PostMapping("${groupbuying.create-url}")
-	public GroupbuyingBoardDTO create(@RequestBody GroupbuyingBoardDTO dto, HttpSession session) {
-		Long userId = (Long)session.getAttribute("userId");
-		Long boardId = commandService.create(dto, userId);
-		return queryService.retrieve(boardId);
-	}
-
 	@PostMapping(value = "${groupbuying.create-url}",
 				 consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public GroupbuyingBoardDTO createV2(@RequestPart GroupbuyingBoardDTO dto,
+	public void createV2(@RequestPart GroupbuyingBoardDTO dto,
 										@RequestPart List<MultipartFile> files,
 										HttpSession session) {
 		Long userId = (Long)session.getAttribute("userId");
 		Long boardId = commandService.create(dto, userId);
-		GroupbuyingBoardDTO retiveBoard = queryService.retrieve(boardId);
-		List<PhotoDTO> uploadItemsList  = fileService.saveFiles(userId, retiveBoard, files);
-		return retiveBoard;
+		GroupbuyingBoardDTO retrieveBoard = queryService.retrieve(boardId);
+		List<PhotoDTO> uploadItemsList  = fileService.saveFiles(userId, retrieveBoard, files);
 	}
 
 	@PostMapping("${groupbuying.update-url}")
-	public GroupbuyingBoardDTO update(@RequestBody GroupbuyingBoardDTO dto) {
+	public void update(@RequestBody GroupbuyingBoardDTO dto) {
 		commandService.update(dto);
-		return queryService.retrieve(dto.getId());
 	}
 
 	//@PostMapping(value ="${groupbuying.update-url}",
@@ -66,10 +61,9 @@ public class GroupbuyingController {
 //	}
 
 	@PostMapping("${groupbuying.order-url}/{id}")
-	public GroupbuyingBoardDTO order(@PathVariable("id") Long id, HttpSession session) {
+	public void order(@PathVariable("id") Long id, HttpSession session) {
 		Long userId = (Long)session.getAttribute("userId");
 		commandService.order(userId, id);
-		return queryService.retrieve(id);
 	}
 
 	@PostMapping("${groupbuying.cancel-url}/{id}")
@@ -81,5 +75,15 @@ public class GroupbuyingController {
 	@GetMapping("${groupbuying.retrieve-url}/{id}")
 	public GroupbuyingBoardDTO retrieve(@PathVariable("id") Long id) {
 		return queryService.retrieve(id);
+	}
+
+	@GetMapping("${groupbuying.retrieve-list-url}/{page}")
+	public Page<GroupbuyingThumbnailDTO> retrieveList(@PathVariable("page") int page) {
+		return queryService.retrieveList(page);
+	}
+
+	@GetMapping("${groupbuying.retrieve-url}")
+	public Page<GroupbuyingThumbnailDTO> retrieveCategoryList(Category category, int page) {
+		return queryService.retrieveCategoryList(category, page);
 	}
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
@@ -1,47 +1,46 @@
 package com.gophagi.nanugi.groupbuying.controller;
 
-import javax.servlet.http.HttpSession;
+import java.util.List;
 
-import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
-import com.gophagi.nanugi.common.util.file.service.FileService;
-import lombok.extern.slf4j.Slf4j;
+import javax.servlet.http.HttpSession;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingThumbnailDTO;
 import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardCommandService;
 import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardQueryService;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
 public class GroupbuyingController {
 	private final GroupbuyingBoardCommandService commandService;
 	private final GroupbuyingBoardQueryService queryService;
-	private final FileService fileService;
 
 	public GroupbuyingController(GroupbuyingBoardCommandService commandService,
-								 GroupbuyingBoardQueryService queryService, FileService fileService) {
+		GroupbuyingBoardQueryService queryService) {
 		this.commandService = commandService;
 		this.queryService = queryService;
-		this.fileService = fileService;
 	}
 
 	@PostMapping(value = "${groupbuying.create-url}",
-				 consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public void createV2(@RequestPart GroupbuyingBoardDTO dto,
-										@RequestPart List<MultipartFile> files,
-										HttpSession session) {
+		@RequestPart List<MultipartFile> files,
+		HttpSession session) {
 		Long userId = (Long)session.getAttribute("userId");
-		Long boardId = commandService.create(dto, userId);
-		GroupbuyingBoardDTO retrieveBoard = queryService.retrieve(boardId);
-		List<PhotoDTO> uploadItemsList  = fileService.saveFiles(userId, retrieveBoard, files);
+		commandService.create(dto, files, userId);
 	}
 
 	@PostMapping("${groupbuying.update-url}")
@@ -51,14 +50,14 @@ public class GroupbuyingController {
 
 	//@PostMapping(value ="${groupbuying.update-url}",
 	//			 consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-//	public GroupbuyingBoardDTO updateV2(@RequestPart GroupbuyingBoardDTO dto,
-//										@RequestPart List<MultipartFile> files) {
-//		commandService.update(dto);
-//		GroupbuyingBoardDTO retiveBoard = queryService.retrieve(dto.getId());
-//		//todo: 이미지 업데이트
-//
-//		return retiveBoard;
-//	}
+	//	public GroupbuyingBoardDTO updateV2(@RequestPart GroupbuyingBoardDTO dto,
+	//										@RequestPart List<MultipartFile> files) {
+	//		commandService.update(dto);
+	//		GroupbuyingBoardDTO retiveBoard = queryService.retrieve(dto.getId());
+	//		//todo: 이미지 업데이트
+	//
+	//		return retiveBoard;
+	//	}
 
 	@PostMapping("${groupbuying.order-url}/{id}")
 	public void order(@PathVariable("id") Long id, HttpSession session) {

--- a/src/main/java/com/gophagi/nanugi/groupbuying/domain/GroupbuyingBoard.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/domain/GroupbuyingBoard.java
@@ -44,10 +44,10 @@ public class GroupbuyingBoard extends BaseTime {
 	private Integer limitedNumberOfParticipants;
 	private String description;
 	private Integer viewCount;
-	@OneToMany(mappedBy = "groupbuyingBoard")
+	@OneToMany(mappedBy = "groupbuyingBoard", orphanRemoval = true)
 	private List<Participant> participants;
 
-	@OneToMany(mappedBy = "groupbuyingBoard")
+	@OneToMany(mappedBy = "groupbuyingBoard", orphanRemoval = true)
 	private List<Photo> photos;
 
 	@Builder

--- a/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingThumbnailDTO.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingThumbnailDTO.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.gophagi.nanugi.common.util.area.Areas;
+import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
 import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.constant.Status;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
@@ -19,60 +19,57 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 @ToString
-public class GroupbuyingBoardDTO {
+public class GroupbuyingThumbnailDTO {
 	private Long id;
+	private PhotoDTO photo;
 	private String title;
 	private Category category;
 	private Status status;
 	private Integer price;
-	private String url;
-	private Areas deliveryArea;
 	private String deliveryAddress;
 	private String deliveryDetailAddress;
 	private LocalDateTime expirationDate;
-	private Integer limitedNumberOfParticipants;
-	private String description;
-	private Integer viewCount;
+	private int limitedNumberOfParticipants;
+	private int numberOfParticipants;
 
 	@Builder
-	public GroupbuyingBoardDTO(Long id, String title, Category category, Status status, Integer price, String url,
-		Areas deliveryArea, String deliveryAddress, String deliveryDetailAddress, LocalDateTime expirationDate,
-		Integer limitedNumberOfParticipants, String description, Integer viewCount) {
+	public GroupbuyingThumbnailDTO(Long id, PhotoDTO photo, String title, Category category, Status status,
+		Integer price,
+		String deliveryAddress, String deliveryDetailAddress, LocalDateTime expirationDate,
+		int limitedNumberOfParticipants,
+		int numberOfParticipants) {
 		this.id = id;
+		this.photo = photo;
 		this.title = title;
 		this.category = category;
 		this.status = status;
 		this.price = price;
-		this.url = url;
-		this.deliveryArea = deliveryArea;
 		this.deliveryAddress = deliveryAddress;
 		this.deliveryDetailAddress = deliveryDetailAddress;
 		this.expirationDate = expirationDate;
 		this.limitedNumberOfParticipants = limitedNumberOfParticipants;
-		this.description = description;
-		this.viewCount = viewCount;
+		this.numberOfParticipants = numberOfParticipants;
 	}
 
-	public static GroupbuyingBoardDTO toGroupbuyingBoardDTO(GroupbuyingBoard groupbuyingBoard) {
-		return GroupbuyingBoardDTO.builder()
+	public static GroupbuyingThumbnailDTO toGroupbuyingThumbnailDTO(GroupbuyingBoard groupbuyingBoard) {
+		return GroupbuyingThumbnailDTO.builder()
 			.id(groupbuyingBoard.getId())
+			.photo(PhotoDTO.toPhotoDTO(groupbuyingBoard.getPhotos().get(0)))
 			.title(groupbuyingBoard.getTitle())
 			.category(groupbuyingBoard.getCategory())
 			.status(groupbuyingBoard.getStatus())
 			.price(groupbuyingBoard.getPrice())
-			.url(groupbuyingBoard.getUrl())
 			.deliveryAddress(groupbuyingBoard.getDeliveryAddress())
 			.deliveryDetailAddress(groupbuyingBoard.getDeliveryDetailAddress())
 			.expirationDate(groupbuyingBoard.getExpirationDate())
 			.limitedNumberOfParticipants(groupbuyingBoard.getLimitedNumberOfParticipants())
-			.description(groupbuyingBoard.getDescription())
-			.viewCount(groupbuyingBoard.getViewCount())
+			.numberOfParticipants(groupbuyingBoard.getParticipants().size())
 			.build();
 	}
 
-	public static List<GroupbuyingBoardDTO> toGroupbuyingBoardDTOs(List<GroupbuyingBoard> groupbuyingBoards) {
+	public static List<GroupbuyingThumbnailDTO> toGroupbuyingThumbnailDTOs(List<GroupbuyingBoard> groupbuyingBoards) {
 		return groupbuyingBoards.stream()
-			.map(GroupbuyingBoardDTO::toGroupbuyingBoardDTO)
+			.map(GroupbuyingThumbnailDTO::toGroupbuyingThumbnailDTO)
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/gophagi/nanugi/groupbuying/repository/GroupbuyingBoardRepository.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/repository/GroupbuyingBoardRepository.java
@@ -1,10 +1,14 @@
 package com.gophagi.nanugi.groupbuying.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
 
 @Repository
 public interface GroupbuyingBoardRepository extends JpaRepository<GroupbuyingBoard, Long> {
+	Page<GroupbuyingBoard> findByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
@@ -96,7 +96,6 @@ public class GroupbuyingBoardCommandService {
 		if (participants.size() > 1) {
 			throw new CannotDeleteBoardException();
 		}
-		participantService.delete(participantId);
 		delete(boardId);
 	}
 

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
@@ -82,7 +82,7 @@ public class GroupbuyingBoardCommandService {
 					participantService.delete(participantId);
 					break;
 				case PROMOTER:
-					tryDeleteAsPromoter(participantId, boardId, participants);
+					tryDeleteAsPromoter(boardId, participants);
 					break;
 			}
 		}
@@ -92,7 +92,7 @@ public class GroupbuyingBoardCommandService {
 		repository.deleteById(id);
 	}
 
-	private void tryDeleteAsPromoter(Long participantId, Long boardId, List<ParticipantDTO> participants) {
+	private void tryDeleteAsPromoter(Long boardId, List<ParticipantDTO> participants) {
 		if (participants.size() > 1) {
 			throw new CannotDeleteBoardException();
 		}

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.gophagi.nanugi.common.util.file.service.FileService;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
 import com.gophagi.nanugi.groupbuying.dto.ParticipantDTO;
@@ -19,26 +21,28 @@ import com.gophagi.nanugi.groupbuying.repository.GroupbuyingBoardRepository;
 public class GroupbuyingBoardCommandService {
 	private final GroupbuyingBoardRepository repository;
 	private final ParticipantService participantService;
+	private final FileService fileService;
 
 	public GroupbuyingBoardCommandService(GroupbuyingBoardRepository repository,
-		ParticipantService participantService) {
+		ParticipantService participantService, FileService fileService) {
 		this.repository = repository;
 		this.participantService = participantService;
+		this.fileService = fileService;
 	}
 
 	@Transactional
-	public Long create(GroupbuyingBoardDTO dto, Long userId) {
+	public void create(GroupbuyingBoardDTO dto, List<MultipartFile> files, Long userId) {
 		if (Objects.isNull(dto)) {
 			throw new NullPointerException("dto is empty");
 		}
 		try {
 			GroupbuyingBoard groupbuyingBoard = GroupbuyingBoard.toGroupbuyingBoard(dto);
 
-			Long boardId = repository.save(groupbuyingBoard).getId();
+			repository.save(groupbuyingBoard);
 
 			participantService.createAsPromoter(userId, groupbuyingBoard);
 
-			return boardId;
+			fileService.saveFiles(userId, groupbuyingBoard, files);
 
 		} catch (Exception exception) {
 			throw new InvalidGroupbuyingBoardInstanceException();

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardQueryService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardQueryService.java
@@ -3,12 +3,17 @@ package com.gophagi.nanugi.groupbuying.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.constant.Role;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
+import com.gophagi.nanugi.groupbuying.dto.GroupbuyingThumbnailDTO;
 import com.gophagi.nanugi.groupbuying.dto.ParticipantDTO;
 import com.gophagi.nanugi.groupbuying.exception.InvalidGroupbuyingBoardInstanceException;
 import com.gophagi.nanugi.groupbuying.repository.GroupbuyingBoardRepository;
@@ -50,5 +55,23 @@ public class GroupbuyingBoardQueryService {
 			groupbuyingBoards.add(GroupbuyingBoardDTO.toGroupbuyingBoardDTO(dto.getGroupbuyingBoard()));
 		}
 		return groupbuyingBoards;
+	}
+
+	@Transactional
+	public Page<GroupbuyingThumbnailDTO> retrieveList(int page) {
+		PageRequest pageRequest = PageRequest.of(page, 20);
+		Page<GroupbuyingBoard> groupbuyingBoards = repository.findAll(pageRequest);
+		return new PageImpl<>(
+			GroupbuyingThumbnailDTO.toGroupbuyingThumbnailDTOs(groupbuyingBoards.getContent()),
+			pageRequest, groupbuyingBoards.getTotalElements());
+	}
+
+	@Transactional
+	public Page<GroupbuyingThumbnailDTO> retrieveCategoryList(Category category, int page) {
+		PageRequest pageRequest = PageRequest.of(page, 20);
+		Page<GroupbuyingBoard> groupbuyingBoards = repository.findByCategory(category, pageRequest);
+		return new PageImpl<>(
+			GroupbuyingThumbnailDTO.toGroupbuyingThumbnailDTOs(groupbuyingBoards.getContent()),
+			pageRequest, groupbuyingBoards.getTotalElements());
 	}
 }

--- a/src/main/resources/application-url.properties
+++ b/src/main/resources/application-url.properties
@@ -3,3 +3,4 @@ groupbuying.updateUrl = groupbuying/update
 groupbuying.orderUrl = groupbuying/order
 groupbuying.cancelUrl = groupbuying/cancel
 groupbuying.retrieveUrl = groupbuying
+groupbuying.retrieveListUrl = groupbuying/list

--- a/src/test/java/com/gophagi/nanugi/groupbuying/GroupbuyingBoardCommandServiceTests.java
+++ b/src/test/java/com/gophagi/nanugi/groupbuying/GroupbuyingBoardCommandServiceTests.java
@@ -3,6 +3,7 @@ package com.gophagi.nanugi.groupbuying;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +13,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.gophagi.nanugi.groupbuying.constant.Role;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
@@ -39,13 +41,15 @@ public class GroupbuyingBoardCommandServiceTests {
 
 	@Test
 	void 공동구매_매개변수가_null_일_때() {
-		assertThatThrownBy(() -> service.create(null, 1L)).isInstanceOf(NullPointerException.class);
+		List<MultipartFile> files = new ArrayList<>();
+		assertThatThrownBy(() -> service.create(null, files, 1L)).isInstanceOf(NullPointerException.class);
 	}
 
 	@Test
 	void 공동구매보드_insert_실패() {
+		List<MultipartFile> files = new ArrayList<>();
 		when(repository.save(ArgumentMatchers.any())).thenThrow(new RuntimeException());
-		assertThatThrownBy(() -> service.create(new GroupbuyingBoardDTO(), 1L)).isInstanceOf(
+		assertThatThrownBy(() -> service.create(new GroupbuyingBoardDTO(), files, 1L)).isInstanceOf(
 			InvalidGroupbuyingBoardInstanceException.class);
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[O] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
khj-95/nanugi-v1.1/master -> GOPHAGI/nanugi-v1.1/master

### 변경 사항
공동구매 보드 삭제 시 연관 관계 객체(참여자,파일) 삭제되도록 JPA 옵션 추가하였습니다.
공동구매 리스트 조회, 카테고리 조회, 페이징 기능 구현했습니다.
공동구매 보드 생성 시 보드 생성, 참여자 생성, 파일 생성하는 로직이 하나의 트랜잭션으로 처리되도록 로직 수정하였습니다.

### 테스트 결과
