### PR TITLE
fix, feat: 이미지 파일 저장 로직 수정 및 공동구매 기능 구현 진행중

### DIFF
--- a/src/main/java/com/gophagi/nanugi/common/util/file/domain/Photo.java
+++ b/src/main/java/com/gophagi/nanugi/common/util/file/domain/Photo.java
@@ -1,54 +1,87 @@
 package com.gophagi.nanugi.common.util.file.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
 import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
+import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
 @NoArgsConstructor
 @Getter
 @Entity
 public class Photo {
-    @Id
-    @Column(name = "FILE_ID")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long fileId;
-    private Long fileIndex;
-    private Long uploaderId;
-    private String uploadFileName;
-    private String storeFileName;
-    private String filetype;
-    private String fileUrl;
-    @ManyToOne
-    private GroupbuyingBoard groupbuyingBoard;
+	@Id
+	@Column(name = "FILE_ID")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long fileId;
+	private Long fileIndex;
+	private Long uploaderId;
+	private String uploadFileName;
+	private String storeFileName;
+	private String filetype;
+	private String fileUrl;
+	@ManyToOne
+	private GroupbuyingBoard groupbuyingBoard;
 
-    @Builder
-    public Photo(Long fileId, Long fileIndex, Long uploaderId,
-                 String uploadFileName, String storeFileName,
-                 String filetype, String fileUrl, GroupbuyingBoard groupbuyingBoard) {
-        this.fileId = fileId;
-        this.fileIndex = fileIndex;
-        this.uploaderId = uploaderId;
-        this.uploadFileName = uploadFileName;
-        this.storeFileName = storeFileName;
-        this.filetype = filetype;
-        this.fileUrl = fileUrl;
-        this.groupbuyingBoard = groupbuyingBoard;
-    }
+	@Builder
+	public Photo(Long fileId, Long fileIndex, Long uploaderId,
+		String uploadFileName, String storeFileName,
+		String filetype, String fileUrl, GroupbuyingBoard groupbuyingBoard) {
+		this.fileId = fileId;
+		this.fileIndex = fileIndex;
+		this.uploaderId = uploaderId;
+		this.uploadFileName = uploadFileName;
+		this.storeFileName = storeFileName;
+		this.filetype = filetype;
+		this.fileUrl = fileUrl;
+		this.groupbuyingBoard = groupbuyingBoard;
+	}
 
-    public static Photo toPhoto(PhotoDTO photoDTO){
-        return Photo.builder()
-                .fileId(photoDTO.getFileId())
-                .fileIndex(photoDTO.getFileIndex())
-                .filetype(photoDTO.getFiletype())
-                .uploaderId(photoDTO.getUploaderId())
-                .storeFileName(photoDTO.getStoreFileName())
-                .uploadFileName(photoDTO.getUploadFileName())
-                .fileUrl(photoDTO.getFileUrl())
-                .groupbuyingBoard(photoDTO.getGroupbuyingBoard())
-                .build();
+	public static Photo toPhoto(PhotoDTO photoDTO) {
+		return Photo.builder()
+			.fileId(photoDTO.getFileId())
+			.fileIndex(photoDTO.getFileIndex())
+			.filetype(photoDTO.getFiletype())
+			.uploaderId(photoDTO.getUploaderId())
+			.storeFileName(photoDTO.getStoreFileName())
+			.uploadFileName(photoDTO.getUploadFileName())
+			.fileUrl(photoDTO.getFileUrl())
+			.groupbuyingBoard(photoDTO.getGroupbuyingBoard())
+			.build();
+	}
 
-    }
+	public void updateGroupbuyingBoard(GroupbuyingBoard groupbuyingBoard) {
+		this.groupbuyingBoard = groupbuyingBoard;
+	}
+
+	public static List<Photo> findNewPhotos(GroupbuyingBoardDTO groupbuyingBoardDTO,
+		GroupbuyingBoard groupbuyingBoard) {
+
+		if (Objects.isNull(groupbuyingBoardDTO.getPhotos())) {
+			return new ArrayList<>();
+		}
+
+		List<Photo> newPhotos = new ArrayList<>();
+		for (PhotoDTO dto : groupbuyingBoardDTO.getPhotos()) {
+			if (Objects.isNull(dto.getFileId())) {
+				Photo newPhoto = Photo.toPhoto(dto);
+				newPhoto.updateGroupbuyingBoard(groupbuyingBoard);
+				newPhotos.add(newPhoto);
+			}
+		}
+		return newPhotos;
+	}
 }

--- a/src/main/java/com/gophagi/nanugi/common/util/file/service/FileService.java
+++ b/src/main/java/com/gophagi/nanugi/common/util/file/service/FileService.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -92,4 +91,7 @@ public class FileService {
 		return  PhotoDTO.toPhotoDTOs(fileRepository.findAllById(deletePhotoIdList));
 	}
 
+	public void saveAllPhotos(List<Photo> photos) {
+		fileRepository.saveAll(photos);
+	}
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/constant/Status.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/constant/Status.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Status {
-	ONGOING("진행중"), DONE("완료");
+	GATHERING("모집중"), ONGOING("모집완료"), DONE("진행완료");
 
-	String name;
+	final String name;
 
 	Status(String name) {
 		this.name = name;
@@ -20,9 +20,11 @@ public enum Status {
 	@JsonCreator
 	public static Status fromValue(String value) {
 		switch (value) {
-			case "진행중":
+			case "모집중":
+				return Status.GATHERING;
+			case "모집완료":
 				return Status.ONGOING;
-			case "완료":
+			case "진행완료":
 				return Status.DONE;
 		}
 		return Status.ONGOING;

--- a/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
@@ -3,14 +3,12 @@ package com.gophagi.nanugi.groupbuying.controller;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.gophagi.nanugi.common.jwt.JwtTokenProvider;
 import com.gophagi.nanugi.groupbuying.constant.Category;
@@ -33,27 +31,23 @@ public class GroupbuyingController {
 		this.queryService = queryService;
 	}
 
-	@PostMapping(value = "${groupbuying.create-url}",
-		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public void create(@RequestPart GroupbuyingBoardDTO dto,
-		@RequestPart List<MultipartFile> files,
-		@CookieValue String token) {
+	@PostMapping(value = "${groupbuying.create-url}")
+	public void create(@RequestBody GroupbuyingBoardDTO dto, @CookieValue String token) {
 
 		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
-		commandService.create(dto, files, userId);
+		commandService.create(dto, userId);
 	}
 
-	@PostMapping(value = "${groupbuying.update-url}",
-		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public void update(@RequestPart GroupbuyingBoardDTO dto,
-		@RequestPart(required = false) List<MultipartFile> files,
-		@RequestPart(required = false) List<Long> deletePhotoIdList,
-		@CookieValue String token) {
+	/* json -> object deserializer 구현해야됨.
+
+	@PostMapping(value = "${groupbuying.update-url}")
+	public void update(@RequestBody GroupbuyingBoardUpdateDTO dto, @CookieValue String token) {
 
 		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
-		commandService.update(dto, files, deletePhotoIdList, userId);
-
+		commandService.update(dto, userId);
 	}
+
+	*/
 
 	@PostMapping("${groupbuying.order-url}/{id}")
 	public void order(@PathVariable("id") Long id, @CookieValue String token) {

--- a/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
@@ -1,17 +1,18 @@
 package com.gophagi.nanugi.groupbuying.controller;
 
-import javax.servlet.http.HttpSession;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.gophagi.nanugi.common.jwt.JwtTokenProvider;
 import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingThumbnailDTO;
@@ -19,8 +20,6 @@ import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardCommandService;
 import com.gophagi.nanugi.groupbuying.service.GroupbuyingBoardQueryService;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -36,38 +35,35 @@ public class GroupbuyingController {
 
 	@PostMapping(value = "${groupbuying.create-url}",
 		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public void createV2(@RequestPart GroupbuyingBoardDTO dto,
+	public void create(@RequestPart GroupbuyingBoardDTO dto,
 		@RequestPart List<MultipartFile> files,
-		HttpSession session) {
-		Long userId = (Long)session.getAttribute("userId");
+		@CookieValue String token) {
+
+		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
 		commandService.create(dto, files, userId);
 	}
 
-	//@PostMapping("${groupbuying.update-url}")
-//	public void update(@RequestBody GroupbuyingBoardDTO dto) {
-//		commandService.update(dto);
-//	}
+	@PostMapping(value = "${groupbuying.update-url}",
+		consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+	public void update(@RequestPart GroupbuyingBoardDTO dto,
+		@RequestPart(required = false) List<MultipartFile> files,
+		@RequestPart(required = false) List<Long> deletePhotoIdList,
+		@CookieValue String token) {
 
-	@PostMapping(value ="${groupbuying.update-url}",
-				 consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-	public void updateV2(@RequestPart GroupbuyingBoardDTO dto,
-										@RequestPart(required = false) List<MultipartFile> files,
-										@RequestPart(required = false) List<Long> deletePhotoIdList,
-										HttpSession session) {
-		Long userId = (Long) session.getAttribute("id");
-		commandService.update(dto, files,deletePhotoIdList, userId);
+		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
+		commandService.update(dto, files, deletePhotoIdList, userId);
 
 	}
 
 	@PostMapping("${groupbuying.order-url}/{id}")
-	public void order(@PathVariable("id") Long id, HttpSession session) {
-		Long userId = (Long)session.getAttribute("userId");
+	public void order(@PathVariable("id") Long id, @CookieValue String token) {
+		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
 		commandService.order(userId, id);
 	}
 
 	@PostMapping("${groupbuying.cancel-url}/{id}")
-	public void cancel(@PathVariable("id") Long id, HttpSession session) {
-		Long userId = (Long)session.getAttribute("userId");
+	public void cancel(@PathVariable("id") Long id, @CookieValue String token) {
+		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
 		commandService.cancel(userId, id);
 	}
 

--- a/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/controller/GroupbuyingController.java
@@ -67,6 +67,12 @@ public class GroupbuyingController {
 		commandService.cancel(userId, id);
 	}
 
+	@PostMapping("${groupbuying.remove-url}/{id}")
+	public List<Long> remove(@PathVariable("id") Long id, @CookieValue String token) {
+		Long userId = Long.parseLong(JwtTokenProvider.getUserNameFromJwt(token));
+		return commandService.remove(userId, id);
+	}
+
 	@GetMapping("${groupbuying.retrieve-url}/{id}")
 	public GroupbuyingBoardDTO retrieve(@PathVariable("id") Long id) {
 		commandService.updateView(id);

--- a/src/main/java/com/gophagi/nanugi/groupbuying/domain/GroupbuyingBoard.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/domain/GroupbuyingBoard.java
@@ -1,7 +1,10 @@
 package com.gophagi.nanugi.groupbuying.domain;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -46,7 +49,6 @@ public class GroupbuyingBoard extends BaseTime {
 	private Integer viewCount;
 	@OneToMany(mappedBy = "groupbuyingBoard", orphanRemoval = true)
 	private List<Participant> participants;
-
 	@OneToMany(mappedBy = "groupbuyingBoard", orphanRemoval = true)
 	private List<Photo> photos;
 
@@ -120,5 +122,22 @@ public class GroupbuyingBoard extends BaseTime {
 			}
 		}
 		return false;
+	}
+
+	public void deletePhoto(List<Long> deletePhotoIdList) {
+		if (Objects.isNull(deletePhotoIdList)) {
+			return;
+		}
+
+		Map<Long, Photo> test = new HashMap<>();
+		for (int i = 0; i < photos.size(); i++) {
+			test.put(photos.get(i).getFileId(), photos.get(i));
+		}
+
+		for (Long deletePhotoId : deletePhotoIdList) {
+			if (test.containsKey(deletePhotoId)) {
+				photos.remove(test.get(deletePhotoId));
+			}
+		}
 	}
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingBoardDTO.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingBoardDTO.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.gophagi.nanugi.common.util.area.Areas;
+import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
 import com.gophagi.nanugi.groupbuying.constant.Category;
 import com.gophagi.nanugi.groupbuying.constant.Status;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
@@ -33,11 +34,12 @@ public class GroupbuyingBoardDTO {
 	private Integer limitedNumberOfParticipants;
 	private String description;
 	private Integer viewCount;
+	private List<PhotoDTO> photos;
 
 	@Builder
 	public GroupbuyingBoardDTO(Long id, String title, Category category, Status status, Integer price, String url,
 		Areas deliveryArea, String deliveryAddress, String deliveryDetailAddress, LocalDateTime expirationDate,
-		Integer limitedNumberOfParticipants, String description, Integer viewCount) {
+		Integer limitedNumberOfParticipants, String description, Integer viewCount, List<PhotoDTO> photos) {
 		this.id = id;
 		this.title = title;
 		this.category = category;
@@ -51,6 +53,7 @@ public class GroupbuyingBoardDTO {
 		this.limitedNumberOfParticipants = limitedNumberOfParticipants;
 		this.description = description;
 		this.viewCount = viewCount;
+		this.photos = photos;
 	}
 
 	public static GroupbuyingBoardDTO toGroupbuyingBoardDTO(GroupbuyingBoard groupbuyingBoard) {
@@ -67,6 +70,7 @@ public class GroupbuyingBoardDTO {
 			.limitedNumberOfParticipants(groupbuyingBoard.getLimitedNumberOfParticipants())
 			.description(groupbuyingBoard.getDescription())
 			.viewCount(groupbuyingBoard.getViewCount())
+			.photos(PhotoDTO.toPhotoDTOs(groupbuyingBoard.getPhotos()))
 			.build();
 	}
 

--- a/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingBoardUpdateDTO.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/dto/GroupbuyingBoardUpdateDTO.java
@@ -1,0 +1,16 @@
+package com.gophagi.nanugi.groupbuying.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class GroupbuyingBoardUpdateDTO extends GroupbuyingBoardDTO {
+	private List<Long> deletePhotoIdList;
+}

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardCommandService.java
@@ -2,33 +2,37 @@ package com.gophagi.nanugi.groupbuying.service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.gophagi.nanugi.common.util.authentication.CommonAuthentication;
 import com.gophagi.nanugi.common.util.file.service.FileService;
+import com.gophagi.nanugi.groupbuying.constant.Status;
 import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
+import com.gophagi.nanugi.groupbuying.domain.Participant;
 import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
 import com.gophagi.nanugi.groupbuying.dto.ParticipantDTO;
-import com.gophagi.nanugi.groupbuying.exception.CannotDeleteBoardException;
 import com.gophagi.nanugi.groupbuying.exception.DuplicateParticipationException;
 import com.gophagi.nanugi.groupbuying.exception.InvalidGroupbuyingBoardInstanceException;
 import com.gophagi.nanugi.groupbuying.exception.PersonnelLimitExceededException;
 import com.gophagi.nanugi.groupbuying.repository.GroupbuyingBoardRepository;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class GroupbuyingBoardCommandService {
 	private final GroupbuyingBoardRepository repository;
 	private final ParticipantService participantService;
 	private final FileService fileService;
+	private final CommonAuthentication authentication;
 
 	public GroupbuyingBoardCommandService(GroupbuyingBoardRepository repository,
-		ParticipantService participantService, FileService fileService) {
+		ParticipantService participantService, FileService fileService, CommonAuthentication authentication) {
 		this.repository = repository;
 		this.participantService = participantService;
 		this.fileService = fileService;
+		this.authentication = authentication;
 	}
 
 	@Transactional
@@ -55,8 +59,7 @@ public class GroupbuyingBoardCommandService {
 		if (Objects.isNull(dto)) {
 			throw new NullPointerException("dto is empty");
 		}
-		GroupbuyingBoard groupbuyingBoard = repository.findById(dto.getId())
-			.orElseThrow(() -> new InvalidGroupbuyingBoardInstanceException());
+		GroupbuyingBoard groupbuyingBoard = getGroupbuyingBoard(dto.getId());
 		groupbuyingBoard.update(dto);
 
 		fileService.updateFiles(dto, files, deletePhotoIdList, userId);
@@ -64,8 +67,7 @@ public class GroupbuyingBoardCommandService {
 
 	@Transactional
 	public void order(Long userId, Long boardId) {
-		GroupbuyingBoard groupbuyingBoard = repository.findById(boardId)
-			.orElseThrow(() -> new InvalidGroupbuyingBoardInstanceException());
+		GroupbuyingBoard groupbuyingBoard = getGroupbuyingBoard(boardId);
 
 		if (groupbuyingBoard.participateInDuplicate(userId)) {
 			throw new DuplicateParticipationException();
@@ -78,40 +80,45 @@ public class GroupbuyingBoardCommandService {
 
 	@Transactional
 	public void cancel(Long userId, Long boardId) {
-		List<ParticipantDTO> participants = participantService.retrieveByBoardId(boardId);
-		for (ParticipantDTO participant : participants) {
-			if (!isUser(participant, userId)) {
-				continue;
-			}
-			Long participantId = participant.getId();
-			switch (participant.getRole()) {
-				case PARTICIPANT:
-					participantService.delete(participantId);
-					break;
-				case PROMOTER:
-					tryDeleteAsPromoter(boardId, participants);
-					break;
-			}
+		ParticipantDTO dto = authentication.isParticipant(userId, boardId);
+
+		GroupbuyingBoard groupbuyingBoard = getGroupbuyingBoard(boardId);
+
+		if (groupbuyingBoard.getStatus() != Status.GATHERING) {
+			throw new IllegalStateException();
 		}
+
+		participantService.delete(dto.getId());
 	}
 
-	private void delete(Long id) {
-		repository.deleteById(id);
-	}
+	@Transactional
+	public List<Long> remove(Long userId, Long boardId) {
 
-	private void tryDeleteAsPromoter(Long boardId, List<ParticipantDTO> participants) {
-		if (participants.size() > 1) {
-			throw new CannotDeleteBoardException();
+		authentication.isPromoter(userId, boardId);
+
+		GroupbuyingBoard groupbuyingBoard = getGroupbuyingBoard(boardId);
+
+		List<Long> participantIds = groupbuyingBoard.getParticipants()
+			.stream()
+			.map(Participant::getId)
+			.collect(Collectors.toList());
+
+		if (groupbuyingBoard.getStatus() == Status.DONE) {
+			throw new RuntimeException();
 		}
-		delete(boardId);
-	}
+		repository.delete(groupbuyingBoard);
 
-	private boolean isUser(ParticipantDTO participant, Long userId) {
-		return participant.getMember().getId().equals(userId);
+		return participantIds;
 	}
 
 	@Transactional
 	public void updateView(Long boardId) {
 		repository.updateView(boardId);
 	}
+
+	private GroupbuyingBoard getGroupbuyingBoard(Long boardId) {
+		return repository.findById(boardId)
+			.orElseThrow(() -> new InvalidGroupbuyingBoardInstanceException());
+	}
+
 }

--- a/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardQueryService.java
+++ b/src/main/java/com/gophagi/nanugi/groupbuying/service/GroupbuyingBoardQueryService.java
@@ -31,37 +31,41 @@ public class GroupbuyingBoardQueryService {
 
 	@Transactional
 	public GroupbuyingBoardDTO retrieve(Long boardId) {
-		GroupbuyingBoard groupbuyingBoard = repository.findById(boardId)
-			.orElseThrow(() -> new InvalidGroupbuyingBoardInstanceException());
-		return GroupbuyingBoardDTO.toGroupbuyingBoardDTO(groupbuyingBoard);
+		return GroupbuyingBoardDTO.toGroupbuyingBoardDTO(getGroupbuyingBoard(boardId));
 	}
 
 	@Transactional
 	public List<GroupbuyingBoardDTO> searchGroupbuyingBoardByUserId(Long userId) {
+
 		List<ParticipantDTO> participants = participantService.retrieveByUserId(userId);
 
 		List<GroupbuyingBoardDTO> groupbuyingBoards = new ArrayList<>();
-		for (ParticipantDTO dto : participants) {
-			groupbuyingBoards.add(dto.getGroupbuyingBoard());
+		for (ParticipantDTO participantDTO : participants) {
+			groupbuyingBoards.add(participantDTO.getGroupbuyingBoard());
 		}
+
 		return groupbuyingBoards;
 	}
 
 	@Transactional
 	public List<GroupbuyingBoardDTO> searchGroupbuyingBoardByUserIdAndRole(Long userId, Role role) {
+
 		List<ParticipantDTO> participants = participantService.retrieveByUserIdAndRole(userId, role);
 
 		List<GroupbuyingBoardDTO> groupbuyingBoards = new ArrayList<>();
 		for (ParticipantDTO dto : participants) {
 			groupbuyingBoards.add(dto.getGroupbuyingBoard());
 		}
+
 		return groupbuyingBoards;
 	}
 
 	@Transactional
 	public Page<GroupbuyingThumbnailDTO> retrieveList(int page) {
+
 		PageRequest pageRequest = PageRequest.of(page, 20);
 		Page<GroupbuyingBoard> groupbuyingBoards = repository.findAll(pageRequest);
+
 		return new PageImpl<>(
 			GroupbuyingThumbnailDTO.toGroupbuyingThumbnailDTOs(groupbuyingBoards.getContent()),
 			pageRequest, groupbuyingBoards.getTotalElements());
@@ -69,16 +73,22 @@ public class GroupbuyingBoardQueryService {
 
 	@Transactional
 	public Page<GroupbuyingThumbnailDTO> retrieveCategoryList(Category category, int page) {
+
 		PageRequest pageRequest = PageRequest.of(page, 20);
 		Page<GroupbuyingBoard> groupbuyingBoards = repository.findByCategory(category, pageRequest);
+
 		return new PageImpl<>(
 			GroupbuyingThumbnailDTO.toGroupbuyingThumbnailDTOs(groupbuyingBoards.getContent()),
 			pageRequest, groupbuyingBoards.getTotalElements());
 	}
 
+	@Transactional
 	public BoardIdAndTitleDTO retrieveBoardIdAndTitleDTO(Long boardId) {
-		GroupbuyingBoard groupbuyingBoard = repository.findById(boardId)
+		return BoardIdAndTitleDTO.toGroupbuyingBoardDTO(getGroupbuyingBoard(boardId));
+	}
+
+	private GroupbuyingBoard getGroupbuyingBoard(Long boardId) {
+		return repository.findById(boardId)
 			.orElseThrow(() -> new InvalidGroupbuyingBoardInstanceException());
-		return BoardIdAndTitleDTO.toGroupbuyingBoardDTO(groupbuyingBoard);
 	}
 }

--- a/src/test/java/com/gophagi/nanugi/common/util/file/PhotoTest.java
+++ b/src/test/java/com/gophagi/nanugi/common/util/file/PhotoTest.java
@@ -1,0 +1,170 @@
+package com.gophagi.nanugi.common.util.file;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.gophagi.nanugi.common.util.file.domain.Photo;
+import com.gophagi.nanugi.common.util.file.dto.PhotoDTO;
+import com.gophagi.nanugi.groupbuying.constant.Category;
+import com.gophagi.nanugi.groupbuying.constant.Status;
+import com.gophagi.nanugi.groupbuying.domain.GroupbuyingBoard;
+import com.gophagi.nanugi.groupbuying.dto.GroupbuyingBoardDTO;
+
+@ExtendWith(MockitoExtension.class)
+public class PhotoTest {
+	private GroupbuyingBoard groupbuyingBoard;
+	private GroupbuyingBoardDTO groupbuyingBoardDTO;
+
+	@BeforeEach
+	void setGroupbuyingBoard() {
+		List<Photo> photos = new ArrayList<>(List.of(
+			Photo.builder()
+				.fileId(1L)
+				.fileIndex(1L)
+				.uploaderId(1L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build(),
+			Photo.builder()
+				.fileId(2L)
+				.fileIndex(2L)
+				.uploaderId(2L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build(),
+			Photo.builder()
+				.fileId(3L)
+				.fileIndex(3L)
+				.uploaderId(3L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build()
+		));
+
+		groupbuyingBoard = GroupbuyingBoard
+			.builder()
+			.id(1L)
+			.title("여기는 제목")
+			.category(Category.HOUSEHOLD_GOODS)
+			.status(Status.GATHERING)
+			.price(10000)
+			.url("http://www.naver.com")
+			.deliveryAddress("서울시 종로구")
+			.deliveryDetailAddress("101-112")
+			.expirationDate(LocalDateTime.now())
+			.limitedNumberOfParticipants(3)
+			.description("설명이 들어가는 자리")
+			.viewCount(0)
+			.photos(photos)
+			.build();
+
+		List<PhotoDTO> photoDTOs = new ArrayList<>(List.of(
+			PhotoDTO.builder()
+				.fileId(1L)
+				.fileIndex(1L)
+				.uploaderId(1L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build(),
+			PhotoDTO.builder()
+				.fileId(2L)
+				.fileIndex(2L)
+				.uploaderId(2L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build(),
+			PhotoDTO.builder()
+				.fileId(3L)
+				.fileIndex(3L)
+				.uploaderId(3L)
+				.uploadFileName("파일 이름")
+				.storeFileName("저장 파일 이름")
+				.filetype("txt")
+				.fileUrl("http://www.naver.com")
+				.build()
+		));
+
+		groupbuyingBoardDTO = GroupbuyingBoardDTO
+			.builder()
+			.id(1L)
+			.title("여기는 제목")
+			.category(Category.HOUSEHOLD_GOODS)
+			.status(Status.GATHERING)
+			.price(10000)
+			.url("http://www.naver.com")
+			.deliveryAddress("서울시 종로구")
+			.deliveryDetailAddress("101-112")
+			.expirationDate(LocalDateTime.now())
+			.limitedNumberOfParticipants(3)
+			.description("설명이 들어가는 자리")
+			.viewCount(0)
+			.photos(photoDTOs)
+			.build();
+	}
+
+	@Test
+	void findNewPhotosWithNoNewPhotoTest() {
+		assertThat(Photo.findNewPhotos(groupbuyingBoardDTO, groupbuyingBoard).size()).isEqualTo(0);
+	}
+
+	@Test
+	void findNewPhotosWithOneNewPhotoTest() {
+		PhotoDTO newPhoto = PhotoDTO.builder()
+			.fileIndex(5L)
+			.uploaderId(5L)
+			.uploadFileName("파일 이름")
+			.storeFileName("저장 파일 이름")
+			.filetype("txt")
+			.fileUrl("http://www.naver.com")
+			.build();
+		groupbuyingBoardDTO.getPhotos().add(newPhoto);
+		assertThat(Photo.findNewPhotos(groupbuyingBoardDTO, groupbuyingBoard).size()).isEqualTo(1);
+	}
+
+	@Test
+	void findNewPhotosWithOneNewPhotoAfterDeleteOnePhotoTest() {
+		groupbuyingBoard.deletePhoto(List.of(2L));
+		groupbuyingBoardDTO.getPhotos().remove(1);
+		PhotoDTO newPhoto = PhotoDTO.builder()
+			.fileIndex(5L)
+			.uploaderId(5L)
+			.uploadFileName("파일 이름")
+			.storeFileName("저장 파일 이름")
+			.filetype("txt")
+			.fileUrl("http://www.naver.com")
+			.build();
+		groupbuyingBoardDTO.getPhotos().add(newPhoto);
+		assertThat(Photo.findNewPhotos(groupbuyingBoardDTO, groupbuyingBoard).size()).isEqualTo(1);
+	}
+
+	@Test
+	void findNewPhotosDTOPhotosIsNullTest() {
+		groupbuyingBoardDTO.setPhotos(null);
+		//assertThatThrownBy(()-> Photo.findNewPhotos(groupbuyingBoardDTO,groupbuyingBoard)).isInstanceOf(NullPointerException.class);
+		assertThat(Photo.findNewPhotos(groupbuyingBoardDTO, groupbuyingBoard).size()).isEqualTo(0);
+	}
+
+	@Test
+	void findNewPhotosWithNoPhotosTest() {
+		groupbuyingBoardDTO.setPhotos(new ArrayList<>());
+		assertThat(Photo.findNewPhotos(groupbuyingBoardDTO, groupbuyingBoard).size()).isEqualTo(0);
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[o] 기능 추가
-[] 기능 삭제
-[o] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) khj-95/nanugi-v1.1/master-> GOPHAGI/nanugi-v1.1/master

### 변경 사항
사용자 닉네임, id 정보를 포함하는 jwt를 cookie에 넣고 이용하기 위해 @CookieValue 어노테이션 사용

메서드명 수정
createV2() -> create
updateV2 -> update

공동 구매 취소 삭제 기능 분리
(기존)
취소/삭제 요청 같은 로직(cancel)에서 role 확인 후 처리
(수정)
취소(cancel), 삭제(remove) 요청 따로 처리 (권한 및 상태 확인)

Status 추가 및 수정
GATHERING(모집중), ONGOING(모집완료), DONE(진행완료)

사용자 정보 조회 시 jwt 토큰 사용
이미지 파일 저장 로직 수정
(기존)
서버에서 이미지 저장(s3) -> url 포함 이미지 정보 DB에 저장 -> 클라이언트에 반환
(수정)
이미지 저장(s3) -> 서버로 url 포함 이미지 정보 전송 -> DB에 이미지 정보 저장 -> 클라이언트에 반환

### 테스트 결과
사진 업데이트 시 새로운 사진만 걸러내는 작업 테스트 -> dto가 null일 경우 빈 ArrayList 반환 처리
